### PR TITLE
Modified CmakeLists.txt so yaml parameter file is in share/ira_laser_tools/config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,8 +77,12 @@ install(TARGETS laserscan_multi_merger laserscan_virtualizer
 )
 
 ## Mark other files for installation (e.g. launch and bag files, etc.)
-install(DIRECTORY launch/ config/
+install(DIRECTORY launch/ 
   DESTINATION share/${PROJECT_NAME}/launch
+)
+
+install(DIRECTORY config/
+  DESTINATION share/${PROJECT_NAME}/config
 )
 
 ament_export_dependencies(${dependencies})


### PR DESCRIPTION
After doing the `colcon build`, the yaml parameter file is transferred to the `/share/ira_laser_tools/launch` folder.
This makes the launch file `merge_multi.launch.py` fail to read the parameter file since it expects it in the folder `/share/ira_laser_tools/config`. Warning message is shown as:

> [WARNING] [launch_ros.actions.node]: Parameter file path is not a file: /ros2_ws/install/ira_laser_tools/share/ira_laser_tools/config/laserscan_merge.yaml

Hence, we need to modify the CMakeLists.txt so it can move the parameter file to the `/share/ira_laser_tools/config` share folder when building.
